### PR TITLE
Added pullrequest for readthedoc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,3 +20,5 @@ Contents
 
    usage
    api
+
+Lumache has its documentation hosted on Read the Docs.


### PR DESCRIPTION
Added 
Lumache has its documentation hosted on Read the Docs.
to docs/source/index.rst to initialize pullrequest